### PR TITLE
Use HostAndPort#toString() in HostAndPort replacement

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinMultiplayerServerListPinger.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinMultiplayerServerListPinger.java
@@ -20,16 +20,13 @@ package de.florianmichael.viafabricplus.injection.mixin.fixes.minecraft;
 import com.google.common.net.HostAndPort;
 import de.florianmichael.viafabricplus.definition.v1_14_4.LegacyServerAddress;
 import de.florianmichael.viafabricplus.injection.access.IServerInfo;
-import net.lenni0451.reflect.Fields;
 import net.lenni0451.reflect.stream.RStream;
 import net.minecraft.client.network.MultiplayerServerListPinger;
 import net.minecraft.client.network.ServerAddress;
 import net.minecraft.client.network.ServerInfo;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -38,7 +35,7 @@ public class MixinMultiplayerServerListPinger {
 
     @Inject(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AllowedAddressResolver;resolve(Lnet/minecraft/client/network/ServerAddress;)Ljava/util/Optional;"), locals = LocalCapture.CAPTURE_FAILHARD)
     public void mapParsing(ServerInfo entry, Runnable saver, CallbackInfo ci, ServerAddress serverAddress) {
-        final ServerAddress remapped = LegacyServerAddress.parse(((IServerInfo) entry).viafabricplus_forcedVersion(), serverAddress.getAddress() + ":" + serverAddress.getPort());
+        final ServerAddress remapped = LegacyServerAddress.parse(((IServerInfo) entry).viafabricplus_forcedVersion(), serverAddress.hostAndPort.toString());
         RStream.of(serverAddress).fields().filter(HostAndPort.class).by(0).set(RStream.of(remapped).fields().filter(HostAndPort.class).by(0).get());
     }
 }

--- a/src/main/resources/viafabricplus.accesswidener
+++ b/src/main/resources/viafabricplus.accesswidener
@@ -5,5 +5,6 @@ accessible field net/minecraft/item/Item ATTACK_DAMAGE_MODIFIER_ID Ljava/util/UU
 accessible field net/minecraft/client/gui/screen/ConnectScreen connection Lnet/minecraft/network/ClientConnection;
 accessible field net/minecraft/network/ClientConnection channel Lio/netty/channel/Channel;
 accessible field net/minecraft/client/network/ServerAddress INVALID Lnet/minecraft/client/network/ServerAddress;
+accessible field net/minecraft/client/network/ServerAddress hostAndPort Lcom/google/common/net/HostAndPort;
 
 accessible class net/minecraft/client/gui/screen/GameModeSelectionScreen$GameModeSelection


### PR DESCRIPTION
Allows for pinging of IPv6 addresses, with ViaFabricPlus installed. Does not seem to break other functionality, from what I've tested.

The reason why this fixes IPv6 pinging is because HostAndPort#toString() constructs bracketed IPv6 addresses, which allows the address to be resolved. Previously, the port was just appended to the address, which malforms the IPv6 address, and does not allow for it to be pinged.

I used an AccessWidener entry here instead of an [Accessor](https://fabricmc.net/wiki/tutorial:mixin_accessors?s[]=accessor), since I can't find any usage of them in your project.

Also, my IDE seems to have automatically cleaned up some unused imports. Oops.