### PR TITLE
Implement PlayerLookTargetProvider

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/protocolhack/ProtocolHack.java
+++ b/src/main/java/de/florianmichael/viafabricplus/protocolhack/ProtocolHack.java
@@ -22,6 +22,7 @@ import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.connection.UserConnectionImpl;
 import com.viaversion.viaversion.protocol.ProtocolPipelineImpl;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.providers.PlayerLookTargetProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.HandItemProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
 import de.florianmichael.viafabricplus.ViaFabricPlus;
@@ -39,6 +40,7 @@ import de.florianmichael.viafabricplus.protocolhack.provider.vialegacy.*;
 import de.florianmichael.viafabricplus.protocolhack.provider.viaversion.ViaFabricPlusHandItemProvider;
 import de.florianmichael.viafabricplus.protocolhack.provider.viaversion.ViaFabricPlusMovementTransmitterProvider;
 import de.florianmichael.viafabricplus.protocolhack.provider.vialoadingbase.ViaFabricPlusVLBBaseVersionProvider;
+import de.florianmichael.viafabricplus.protocolhack.provider.viaversion.ViaFabricPlusPlayerLookTargetProvider;
 import de.florianmichael.vialoadingbase.ViaLoadingBase;
 import de.florianmichael.vialoadingbase.model.ComparableProtocolVersion;
 import de.florianmichael.vialoadingbase.model.Platform;
@@ -147,6 +149,7 @@ public class ProtocolHack {
 
             providers.use(MovementTransmitterProvider.class, new ViaFabricPlusMovementTransmitterProvider());
             providers.use(HandItemProvider.class, new ViaFabricPlusHandItemProvider());
+            providers.use(PlayerLookTargetProvider.class, new ViaFabricPlusPlayerLookTargetProvider());
 
             providers.use(CommandArgumentsProvider.class, new ViaFabricPlusCommandArgumentsProvider());
 

--- a/src/main/java/de/florianmichael/viafabricplus/protocolhack/provider/viaversion/ViaFabricPlusPlayerLookTargetProvider.java
+++ b/src/main/java/de/florianmichael/viafabricplus/protocolhack/provider/viaversion/ViaFabricPlusPlayerLookTargetProvider.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/FlorianMichael/ViaFabricPlus
+ * Copyright (C) 2021-2023 FlorianMichael/EnZaXD and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.florianmichael.viafabricplus.protocolhack.provider.viaversion;
+
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.minecraft.Position;
+import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.providers.PlayerLookTargetProvider;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class ViaFabricPlusPlayerLookTargetProvider extends PlayerLookTargetProvider {
+    @Override
+    public @Nullable Position getPlayerLookTarget(UserConnection info) {
+        HitResult crosshairTarget = MinecraftClient.getInstance().crosshairTarget;
+        if (crosshairTarget instanceof BlockHitResult blockHitResult) {
+            BlockPos pos = blockHitResult.getBlockPos();
+            return new Position(pos.getX(), pos.getY(), pos.getZ());
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This allows tab completion to properly complete block coordinates when looking at a block.
Note that this requires a new ViaVersion provider, so you may need to refresh dependencies to get the new ViaVersion snapshot.