### PR TITLE
Make README.md less problematic for random people

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Contributions in the form of pull requests are always welcome, please just stick
 Translations for other languages are always welcome, in **~/resources/assets/viafabricplus/lang** you can find all translations, <br>
 if you know a language well, feel free to make a PR and add translations for that language <br>
 
-### Dependencies
+### Dependencies (for compiling only, **you do not need to install these on the client!**)
 <details>
   <summary>Click to get a list of all dependencies</summary>
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Contributions in the form of pull requests are always welcome, please just stick
 Translations for other languages are always welcome, in **~/resources/assets/viafabricplus/lang** you can find all translations, <br>
 if you know a language well, feel free to make a PR and add translations for that language <br>
 
-### Dependencies (for compiling only, **you do not need to install these on the client!**)
+### Dependencies
+For compiling only! **You do not need to install these!**
 <details>
   <summary>Click to get a list of all dependencies</summary>
 


### PR DESCRIPTION
I myself thought that I have to install these when I first encountered this mod! I know it's in the "For developers and translators" section, but not everybody reads the whole readme - people just scan it with eyes, and when they see "dependencies", they try to install them.